### PR TITLE
feat(web): supabase Auth 認証フローとセキュリティ修正を追加

### DIFF
--- a/apps/web/src/lib/auth.middleware.ts
+++ b/apps/web/src/lib/auth.middleware.ts
@@ -2,13 +2,22 @@ import type { MiddlewareFunction } from "react-router";
 import { userContext } from "../context";
 import { createSupabaseServerClient } from "./supabase/server";
 
-export const authMiddleware: MiddlewareFunction<Response> = async ({
-  request,
-  context,
-}) => {
-  const { supabase } = createSupabaseServerClient(request);
+export const authMiddleware: MiddlewareFunction<Response> = async (
+  { request, context },
+  next,
+) => {
+  const { supabase, headers } = createSupabaseServerClient(request);
   const {
     data: { user },
   } = await supabase.auth.getUser();
   context.set(userContext, user ?? null);
+
+  const response = await next();
+
+  // Merge Set-Cookie headers from Supabase (e.g. token refresh)
+  for (const value of headers.getSetCookie()) {
+    response.headers.append("Set-Cookie", value);
+  }
+
+  return response;
 };

--- a/apps/web/src/lib/supabase/server.ts
+++ b/apps/web/src/lib/supabase/server.ts
@@ -1,4 +1,8 @@
-import { createServerClient, parseCookieHeader } from "@supabase/ssr";
+import {
+  createServerClient,
+  parseCookieHeader,
+  serializeCookieHeader,
+} from "@supabase/ssr";
 
 export function createSupabaseServerClient(request: Request) {
   const supabaseUrl = process.env.SUPABASE_URL;
@@ -22,28 +26,14 @@ export function createSupabaseServerClient(request: Request) {
       },
       setAll(cookiesToSet) {
         for (const { name, value, options } of cookiesToSet) {
-          headers.append("Set-Cookie", serializeCookie(name, value, options));
+          headers.append(
+            "Set-Cookie",
+            serializeCookieHeader(name, value, options),
+          );
         }
       },
     },
   });
 
   return { supabase, headers };
-}
-
-function serializeCookie(
-  name: string,
-  value: string,
-  options?: Record<string, unknown>,
-): string {
-  let cookie = `${name}=${encodeURIComponent(value)}`;
-  if (options) {
-    if (options.path) cookie += `; Path=${options.path}`;
-    if (options.maxAge) cookie += `; Max-Age=${options.maxAge}`;
-    if (options.domain) cookie += `; Domain=${options.domain}`;
-  }
-  cookie += options?.httpOnly !== false ? "; HttpOnly" : "";
-  cookie += options?.secure !== false ? "; Secure" : "";
-  cookie += `; SameSite=${options?.sameSite ?? "Lax"}`;
-  return cookie;
 }

--- a/apps/web/src/lib/validators/auth.ts
+++ b/apps/web/src/lib/validators/auth.ts
@@ -1,0 +1,28 @@
+import { z } from "zod";
+
+export const emailSchema = z.email("有効なメールアドレスを入力してください");
+
+export const passwordSchema = z
+  .string()
+  .min(8, "パスワードは8文字以上で入力してください")
+  .max(128, "パスワードは128文字以下で入力してください");
+
+export const usernameSchema = z
+  .string()
+  .min(3, "ユーザー名は3文字以上で入力してください")
+  .max(30, "ユーザー名は30文字以下で入力してください")
+  .regex(/^[a-z0-9_]+$/, "英小文字・数字・アンダースコアのみ使用できます");
+
+export const loginSchema = z.object({
+  email: emailSchema,
+  password: z.string().min(1, "パスワードを入力してください"),
+});
+
+export const signupSchema = z.object({
+  email: emailSchema,
+  password: passwordSchema,
+  username: usernameSchema,
+});
+
+export type LoginInput = z.infer<typeof loginSchema>;
+export type SignupInput = z.infer<typeof signupSchema>;

--- a/apps/web/src/routes.ts
+++ b/apps/web/src/routes.ts
@@ -1,3 +1,20 @@
-import { index, type RouteConfig } from "@react-router/dev/routes";
+import {
+  index,
+  layout,
+  type RouteConfig,
+  route,
+} from "@react-router/dev/routes";
 
-export default [index("routes/home.tsx")] satisfies RouteConfig;
+export default [
+  index("routes/home.tsx"),
+
+  // Auth routes (unauthenticated)
+  layout("routes/auth/layout.tsx", [
+    route("auth/login", "routes/auth/login.tsx"),
+    route("auth/signup", "routes/auth/signup.tsx"),
+    route("auth/callback", "routes/auth/callback.tsx"),
+  ]),
+
+  // App routes (authenticated)
+  layout("routes/app/layout.tsx", [route("feed", "routes/app/feed.tsx")]),
+] satisfies RouteConfig;

--- a/apps/web/src/routes/app/feed.tsx
+++ b/apps/web/src/routes/app/feed.tsx
@@ -1,0 +1,12 @@
+import { Heading, Text, VStack } from "@chakra-ui/react";
+
+export default function FeedPage() {
+  return (
+    <VStack gap="4" p="8">
+      <Heading as="h1" size="2xl">
+        フィード
+      </Heading>
+      <Text color="fg.muted">投稿はまだありません。</Text>
+    </VStack>
+  );
+}

--- a/apps/web/src/routes/app/layout.tsx
+++ b/apps/web/src/routes/app/layout.tsx
@@ -1,0 +1,22 @@
+import { Box } from "@chakra-ui/react";
+import { Outlet, redirect } from "react-router";
+import type { Route } from "./+types/layout";
+import { userContext } from "@/context";
+import { authMiddleware } from "@/lib/auth.middleware";
+
+export const middleware = [authMiddleware];
+
+export function loader({ context }: Route.LoaderArgs) {
+  const user = context.get(userContext);
+  if (!user) {
+    throw redirect("/auth/login");
+  }
+}
+
+export default function AppLayout() {
+  return (
+    <Box minH="100vh">
+      <Outlet />
+    </Box>
+  );
+}

--- a/apps/web/src/routes/auth/callback.tsx
+++ b/apps/web/src/routes/auth/callback.tsx
@@ -1,0 +1,21 @@
+import { redirect } from "react-router";
+import type { Route } from "./+types/callback";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export async function loader({ request }: Route.LoaderArgs) {
+  const url = new URL(request.url);
+  const code = url.searchParams.get("code");
+
+  if (!code) {
+    throw redirect("/auth/login");
+  }
+
+  const { supabase, headers } = createSupabaseServerClient(request);
+  const { error } = await supabase.auth.exchangeCodeForSession(code);
+
+  if (error) {
+    throw redirect("/auth/login");
+  }
+
+  return redirect("/feed", { headers });
+}

--- a/apps/web/src/routes/auth/layout.tsx
+++ b/apps/web/src/routes/auth/layout.tsx
@@ -1,0 +1,36 @@
+import { Box, Container, Heading, VStack } from "@chakra-ui/react";
+import { Outlet, redirect } from "react-router";
+import type { Route } from "./+types/layout";
+import { userContext } from "@/context";
+import { authMiddleware } from "@/lib/auth.middleware";
+
+export const middleware = [authMiddleware];
+
+export function loader({ context }: Route.LoaderArgs) {
+  const user = context.get(userContext);
+  if (user) {
+    throw redirect("/feed");
+  }
+}
+
+export default function AuthLayout() {
+  return (
+    <Box
+      minH="100vh"
+      display="flex"
+      alignItems="center"
+      justifyContent="center"
+    >
+      <Container maxW="sm" py="12">
+        <VStack gap="8">
+          <Heading as="h1" size="3xl" textAlign="center">
+            My Portal
+          </Heading>
+          <Box w="full">
+            <Outlet />
+          </Box>
+        </VStack>
+      </Container>
+    </Box>
+  );
+}

--- a/apps/web/src/routes/auth/login.tsx
+++ b/apps/web/src/routes/auth/login.tsx
@@ -1,0 +1,119 @@
+import {
+  Button,
+  Link as ChakraLink,
+  Fieldset,
+  Input,
+  Stack,
+  Text,
+} from "@chakra-ui/react";
+import {
+  Form,
+  Link,
+  redirect,
+  useActionData,
+  useNavigation,
+} from "react-router";
+import type { Route } from "./+types/login";
+import { Field } from "@/components/ui/field";
+import { PasswordInput } from "@/components/ui/password-input";
+import { userContext } from "@/context";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { loginSchema } from "@/lib/validators/auth";
+
+export function loader({ context }: Route.LoaderArgs) {
+  const user = context.get(userContext);
+  if (user) {
+    throw redirect("/feed");
+  }
+}
+
+type ActionErrors = {
+  form?: string[];
+  email?: string[];
+  password?: string[];
+};
+
+export async function action({ request }: Route.ActionArgs) {
+  const formData = await request.formData();
+  const result = loginSchema.safeParse({
+    email: formData.get("email"),
+    password: formData.get("password"),
+  });
+
+  if (!result.success) {
+    const errors: ActionErrors = {};
+    for (const issue of result.error.issues) {
+      const key = issue.path[0] as keyof ActionErrors;
+      errors[key] ??= [];
+      errors[key].push(issue.message);
+    }
+    return { errors };
+  }
+
+  const { supabase, headers } = createSupabaseServerClient(request);
+  const { error } = await supabase.auth.signInWithPassword({
+    email: result.data.email,
+    password: result.data.password,
+  });
+
+  if (error) {
+    return {
+      errors: {
+        form: ["メールアドレスまたはパスワードが正しくありません"],
+      } as ActionErrors,
+    };
+  }
+
+  return redirect("/feed", { headers });
+}
+
+export default function LoginPage() {
+  const actionData = useActionData<typeof action>();
+  const navigation = useNavigation();
+  const isSubmitting = navigation.state === "submitting";
+
+  return (
+    <Form method="post">
+      <Fieldset.Root>
+        <Stack gap="4">
+          <Fieldset.Legend fontSize="xl" fontWeight="bold">
+            ログイン
+          </Fieldset.Legend>
+
+          {actionData?.errors?.form && (
+            <Text color="fg.error" fontSize="sm">
+              {actionData.errors.form[0]}
+            </Text>
+          )}
+
+          <Field
+            label="メールアドレス"
+            invalid={!!actionData?.errors?.email}
+            errorText={actionData?.errors?.email?.[0]}
+          >
+            <Input name="email" type="email" placeholder="you@example.com" />
+          </Field>
+
+          <Field
+            label="パスワード"
+            invalid={!!actionData?.errors?.password}
+            errorText={actionData?.errors?.password?.[0]}
+          >
+            <PasswordInput name="password" placeholder="パスワード" />
+          </Field>
+
+          <Button type="submit" colorPalette="blue" loading={isSubmitting}>
+            ログイン
+          </Button>
+
+          <Text fontSize="sm" textAlign="center">
+            アカウントをお持ちでない方は{" "}
+            <ChakraLink asChild colorPalette="blue">
+              <Link to="/auth/signup">サインアップ</Link>
+            </ChakraLink>
+          </Text>
+        </Stack>
+      </Fieldset.Root>
+    </Form>
+  );
+}

--- a/apps/web/src/routes/auth/signup.tsx
+++ b/apps/web/src/routes/auth/signup.tsx
@@ -1,0 +1,134 @@
+import {
+  Button,
+  Link as ChakraLink,
+  Fieldset,
+  Input,
+  Stack,
+  Text,
+} from "@chakra-ui/react";
+import {
+  Form,
+  Link,
+  redirect,
+  useActionData,
+  useNavigation,
+} from "react-router";
+import type { Route } from "./+types/signup";
+import { Field } from "@/components/ui/field";
+import { PasswordInput } from "@/components/ui/password-input";
+import { userContext } from "@/context";
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+import { signupSchema } from "@/lib/validators/auth";
+
+export function loader({ context }: Route.LoaderArgs) {
+  const user = context.get(userContext);
+  if (user) {
+    throw redirect("/feed");
+  }
+}
+
+type ActionErrors = {
+  form?: string[];
+  email?: string[];
+  password?: string[];
+  username?: string[];
+};
+
+export async function action({ request }: Route.ActionArgs) {
+  const formData = await request.formData();
+  const result = signupSchema.safeParse({
+    email: formData.get("email"),
+    password: formData.get("password"),
+    username: formData.get("username"),
+  });
+
+  if (!result.success) {
+    const errors: ActionErrors = {};
+    for (const issue of result.error.issues) {
+      const key = issue.path[0] as keyof ActionErrors;
+      errors[key] ??= [];
+      errors[key].push(issue.message);
+    }
+    return { errors };
+  }
+
+  const { supabase, headers } = createSupabaseServerClient(request);
+  const { error } = await supabase.auth.signUp({
+    email: result.data.email,
+    password: result.data.password,
+    options: {
+      data: { username: result.data.username },
+    },
+  });
+
+  if (error) {
+    return {
+      errors: {
+        form: [
+          "アカウントの作成に失敗しました。しばらくしてからお試しください",
+        ],
+      } as ActionErrors,
+    };
+  }
+
+  return redirect("/feed", { headers });
+}
+
+export default function SignupPage() {
+  const actionData = useActionData<typeof action>();
+  const navigation = useNavigation();
+  const isSubmitting = navigation.state === "submitting";
+
+  return (
+    <Form method="post">
+      <Fieldset.Root>
+        <Stack gap="4">
+          <Fieldset.Legend fontSize="xl" fontWeight="bold">
+            サインアップ
+          </Fieldset.Legend>
+
+          {actionData?.errors?.form && (
+            <Text color="fg.error" fontSize="sm">
+              {actionData.errors.form[0]}
+            </Text>
+          )}
+
+          <Field
+            label="ユーザー名"
+            invalid={!!actionData?.errors?.username}
+            errorText={actionData?.errors?.username?.[0]}
+          >
+            <Input name="username" placeholder="your_username" />
+          </Field>
+
+          <Field
+            label="メールアドレス"
+            invalid={!!actionData?.errors?.email}
+            errorText={actionData?.errors?.email?.[0]}
+          >
+            <Input name="email" type="email" placeholder="you@example.com" />
+          </Field>
+
+          <Field
+            label="パスワード"
+            invalid={!!actionData?.errors?.password}
+            errorText={actionData?.errors?.password?.[0]}
+          >
+            <PasswordInput name="password" placeholder="8文字以上" />
+          </Field>
+
+          <Button type="submit" colorPalette="blue" loading={isSubmitting}>
+            サインアップ
+          </Button>
+
+          <Text fontSize="sm" textAlign="center">
+            すでにアカウントをお持ちの方は{" "}
+            <ChakraLink asChild colorPalette="blue">
+              <Link to="/auth/login">ログイン</Link>
+            </ChakraLink>
+          </Text>
+        </Stack>
+      </Fieldset.Root>
+    </Form>
+  );
+}


### PR DESCRIPTION
## Summary

- Supabase Auth による認証フロー実装（ログイン・サインアップ・OAuth コールバック）
- Zod バリデーションスキーマ（email, password max128, username）
- 認証レイアウト（ロゴ + 中央寄せ、認証済みなら `/feed` リダイレクト）
- 認証済みレイアウト（authMiddleware で保護、未認証は `/auth/login` リダイレクト）
- `serializeCookie` 独自実装を `@supabase/ssr` 公式 `serializeCookieHeader` に置換（CRLF インジェクション防止）
- `authMiddleware` で `next()` 後にレスポンスへ Set-Cookie をマージ（セッション Cookie リフレッシュ対応）
- エラーメッセージを汎用化（ユーザー列挙攻撃防止）

Closes #4

## Test plan

- [ ] `pnpm check-types` / `pnpm lint` / `pnpm test` が通る
- [ ] Email/Password でサインアップ → users テーブルにプロフィール自動作成
- [ ] Email/Password でログイン → `/feed` にリダイレクト
- [ ] 未認証で `/feed` にアクセス → `/auth/login` にリダイレクト
- [ ] 認証済みで `/auth/login` にアクセス → `/feed` にリダイレクト
- [ ] バリデーションエラー（短いパスワード、無効なメール等）が表示される
- [ ] セッション Cookie リフレッシュが正常に動作する

🤖 Generated with [Claude Code](https://claude.com/claude-code)